### PR TITLE
Add exclude option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@easy-webpack/config-uglify",
   "description": "Easy Webpack configuration function for uglify",
   "main": "dist/index.js",
+  "version": "0.0.1",
   "typings": "dist/index.d.ts",
   "scripts": {
     "test": "TS_NODE_FAST=true TS_NODE_NO_PROJECT=true ava",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@easy-webpack/config-uglify",
   "description": "Easy Webpack configuration function for uglify",
   "main": "dist/index.js",
-  "version": "0.0.1",
   "typings": "dist/index.d.ts",
   "scripts": {
     "test": "TS_NODE_FAST=true TS_NODE_NO_PROJECT=true ava",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import * as webpack from 'webpack'
  *
  * See: https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
  */
-export = function uglify({debug = false} = {}) {
+export = function uglify({debug = false, exclude = []} = {}) {
   return function uglify(this: WebpackConfig): WebpackConfig {
     const options = debug ? {
       beautify: true, //debug
@@ -25,19 +25,19 @@ export = function uglify({debug = false} = {}) {
       }, // debug
       comments: true, //debug
     } : {
-      beautify: true, //prod
+      beautify: false, //prod
 
       mangle: {
         screw_ie8 : true,
         keep_fnames: true
       }, //prod
-
+	  exclude:  exclude,
       compress: {
         screw_ie8: true,
         warnings: false
       }, //prod
 
-      comments: true //prod
+      comments: false //prod
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,9 @@ export = function uglify({debug = false, exclude = []} = {}) {
         screw_ie8 : true,
         keep_fnames: true
       }, //prod
-	  exclude:  exclude,
+
+      exclude: exclude,
+
       compress: {
         screw_ie8: true,
         warnings: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export = function uglify({debug = false} = {}) {
       }, // debug
       comments: true, //debug
     } : {
-      beautify: false, //prod
+      beautify: true, //prod
 
       mangle: {
         screw_ie8 : true,
@@ -37,7 +37,7 @@ export = function uglify({debug = false} = {}) {
         warnings: false
       }, //prod
 
-      comments: false //prod
+      comments: true //prod
     }
 
     return {


### PR DESCRIPTION
For certain libraries the uglify plugin has to be excepted. Passing the exclude option to the plugin helps configuring this the easy way.

I did insert a version field in package.json for direct npm usage.
