### PR TITLE
make mangle option confiurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import * as webpack from 'webpack'
  *
  * See: https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
  */
-export = function uglify({debug = false, exclude = []} = {}) {
+export = function uglify({debug = false, exclude = [], mangle = {screw_ie8 : true, keep_fnames: true}} = {}) {
   return function uglify(this: WebpackConfig): WebpackConfig {
     const options = debug ? {
       beautify: true, //debug
@@ -27,10 +27,7 @@ export = function uglify({debug = false, exclude = []} = {}) {
     } : {
       beautify: false, //prod
 
-      mangle: {
-        screw_ie8 : true,
-        keep_fnames: true
-      }, //prod
+      mangle: mangle, //prod
 
       exclude: exclude,
 


### PR DESCRIPTION
Why? => If I mangle Aurelia, I get an error because the aurelia framework is mangled. The solution is to set "expect" in mangle and list "Aurelia".

You can experience this here https://github.com/aurelia/skeleton-navigation/tree/master/skeleton-typescript-webpack

It's also useful for other 3th party libraries to not be mangled.
